### PR TITLE
fix: add support for react 17.x when using npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "qr.js": "0.0.0"
   },
   "peerDependencies": {
-    "react": "^16.x"
+    "react": "^16.x || ^17.x"
   },
   "devDependencies": {
     "babel": "^6.23.0",


### PR DESCRIPTION
Hello. I am using npm version 7 in project and there was an error when I tried to install this package.
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: project@0.1.0
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"^17.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.x" from react-qr-code@1.1.0
npm ERR! node_modules/react-qr-code
npm ERR!   react-qr-code@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/flame/.npm/eresolve-report.txt for a full report.
```

I think this PR should fix this issue.
