### PR TITLE
update property type-defintion to include all valid SVGElement props

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'react-qr-code' {
   import * as React from 'react'
 
-  export interface QRCodeProps {
+  export interface QRCodeProps extends React.HTMLProps<SVGElement> {
     value: string
     size?: number // defaults to 128
     bgColor?: string // defaults to '#FFFFFF'


### PR DESCRIPTION
Inside the QRComponent all props that are not explicitly used are passed down to the svg-element rendered inside the QRCodeSurface component.
Therefore the prop definition should include all valid properties of the SVG-element.