### PR TITLE
Add viewBox for easier responsive design

### DIFF
--- a/src/components/QRCodeSurface/index.js
+++ b/src/components/QRCodeSurface/index.js
@@ -14,7 +14,9 @@ const defaultProps = {
 };
 
 const QRCodeSurface = ({ children, size, title, xmlns, ...props }) => (
-  <svg {...props} height={size} width={size} xmlns={xmlns}>
+  const viewBox = "0 0 " + size + " " + size;
+  
+  <svg {...props} height={size} width={size} viewBox={viewBox} xmlns={xmlns}>
     {title ? <title>{title}</title> : null}
     {children}
   </svg>


### PR DESCRIPTION
I personally would skip the width and heigth and only set the viewBox but that would be a bc break. Width adding the viewBox it is possible via:

```css
.qrcode {
    height: auto;
    width: 100%;
    max-width: 256px;
}
```

to scale the qr code.