### PR TITLE
Add: render type to fix typescript error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,9 @@ declare module "react-qr-code" {
     level?: string; // defaults to 'L' , Can be one of 'L,M,H,Q'
   }
 
-  class QRCode extends React.Component<QRCodeProps, any> {}
+  class QRCode extends React.Component<QRCodeProps, any> {
+    render(): JSX.Element
+  }
 
   export default QRCode;
 }


### PR DESCRIPTION
# In this PR
* Adding a render type to the QRCode Class to remove the following error in tsx files:
<img width="955" alt="Screen Shot 2022-09-01 at 10 56 58 AM" src="https://user-images.githubusercontent.com/18640611/187946110-6a55f2e9-e697-4c5f-a92b-cbb31bcff032.png">
