### PR TITLE
fix(index.d.ts): adjusting QRCodeProps type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 declare module "react-qr-code" {
   import * as React from "react";
 
-  export interface QRCodeProps extends React.SVGProps<SVGElement> {
+  export interface QRCodeProps extends React.SVGProps<SVGSVGElement> {
     value: string;
     size?: number; // defaults to 128
     bgColor?: string; // defaults to '#FFFFFF'
@@ -10,7 +10,7 @@ declare module "react-qr-code" {
   }
 
   class QRCode extends React.Component<QRCodeProps, any> {
-    render(): JSX.Element
+    render(): JSX.Element;
   }
 
   export default QRCode;


### PR DESCRIPTION
I'm fixing a error type, so the component gets the viewBox prop

![Screenshot_20221005_211747](https://user-images.githubusercontent.com/56457600/194186425-a2c2a64c-6531-4f38-9853-41c74874a96c.png)
![Screenshot_20221005_211815](https://user-images.githubusercontent.com/56457600/194186457-0490b92e-beb5-4ccb-9f7c-a3e7a6b53e69.png)
