### PR TITLE
Make the code readable at any size + dom size optimization

### DIFF
--- a/src/components/QRCodeCell/index.js
+++ b/src/components/QRCodeCell/index.js
@@ -4,14 +4,12 @@ import React from "react";
 const propTypes = {
   d: PropTypes.string.isRequired,
   fill: PropTypes.string.isRequired,
-  transformX: PropTypes.number.isRequired,
-  transformY: PropTypes.number.isRequired,
 };
 
 const defaultProps = {};
 
-const QRCodeCell = ({ d, fill, transformX, transformY }) => (
-  <path d={d} fill={fill} transform={`matrix(${[1, 0, 0, 1, transformX, transformY]})`} />
+const QRCodeCell = ({ d, fill }) => (
+  <path d={d} fill={fill} />
 );
 
 QRCodeCell.propTypes = propTypes;

--- a/src/components/QRCodeCell/index.native.js
+++ b/src/components/QRCodeCell/index.native.js
@@ -5,13 +5,11 @@ import { Path } from "react-native-svg";
 const propTypes = {
   d: PropTypes.string.isRequired,
   fill: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  transformX: PropTypes.number.isRequired,
-  transformY: PropTypes.number.isRequired,
 };
 
 const defaultProps = {};
 
-const QRCodeCell = ({ d, fill, transformX, transformY }) => <Path d={d} fill={fill} x={transformX} y={transformY} />;
+const QRCodeCell = ({ d, fill }) => <Path d={d} fill={fill} />;
 
 QRCodeCell.propTypes = propTypes;
 QRCodeCell.defaultProps = defaultProps;

--- a/src/components/QRCodeSurface/index.js
+++ b/src/components/QRCodeSurface/index.js
@@ -4,6 +4,8 @@ import React, { forwardRef } from "react";
 const propTypes = {
   children: PropTypes.array.isRequired,
   size: PropTypes.number.isRequired,
+  length: PropTypes.number.isRequired,
+  bgColor: PropTypes.string.isRequired,
   title: PropTypes.string,
   xmlns: PropTypes.string,
 };
@@ -13,9 +15,10 @@ const defaultProps = {
   xmlns: "http://www.w3.org/2000/svg",
 };
 
-const QRCodeSurface = forwardRef(({ children, size, title, xmlns, ...props }, ref) => (
-  <svg {...props} height={size} ref={ref} width={size} xmlns={xmlns}>
+const QRCodeSurface = forwardRef(({ children, size, length, title, xmlns, bgColor, ...props }, ref) => (
+  <svg {...props} height={size} ref={ref} width={size} xmlns={xmlns} viewBox={`0 0 ${length} ${length}`}>
     {title ? <title>{title}</title> : null}
+    <rect x={0} y={0} width={length} height={length} fill={bgColor}/>
     {children}
   </svg>
 ));

--- a/src/components/QRCodeSurface/index.js
+++ b/src/components/QRCodeSurface/index.js
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 const propTypes = {
   children: PropTypes.array.isRequired,
   size: PropTypes.number.isRequired,
-  length: PropTypes.number.isRequired,
+  dataSize: PropTypes.number.isRequired,
   bgColor: PropTypes.string.isRequired,
   title: PropTypes.string,
   xmlns: PropTypes.string,
@@ -15,10 +15,17 @@ const defaultProps = {
   xmlns: "http://www.w3.org/2000/svg",
 };
 
-const QRCodeSurface = forwardRef(({ children, size, length, title, xmlns, bgColor, ...props }, ref) => (
-  <svg {...props} height={size} ref={ref} width={size} xmlns={xmlns} viewBox={`0 0 ${length} ${length}`}>
+const QRCodeSurface = forwardRef(({ bgColor, dataSize, size, title, xmlns, children, ...props }, ref) => (
+  <svg
+    {...props}
+    ref={ref}
+    height={size}
+    width={size}
+    viewBox={`0 0 ${dataSize} ${dataSize}`}
+    xmlns={xmlns}
+  >
     {title ? <title>{title}</title> : null}
-    <rect x={0} y={0} width={length} height={length} fill={bgColor}/>
+    <rect x={0} y={0} width={dataSize} height={dataSize} fill={bgColor}/>
     {children}
   </svg>
 ));

--- a/src/components/QRCodeSurface/index.native.js
+++ b/src/components/QRCodeSurface/index.native.js
@@ -5,15 +5,22 @@ import { Svg, Rect } from "react-native-svg";
 const propTypes = {
   children: PropTypes.array.isRequired,
   size: PropTypes.number.isRequired,
-  length: PropTypes.number.isRequired,
+  dataSize: PropTypes.number.isRequired,
   bgColor: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
-const QRCodeSurface = forwardRef(({ children, size, length, bgColor, ...props }, ref) => (
-  <Svg {...props} height={size} ref={ref} style={{ height: size, width: size }} width={size}>
-    <Rect x={0} y={0} width={length} height={length} fill={bgColor}/>
+const QRCodeSurface = forwardRef(({ bgColor, dataSize, size, children, ...props }, ref) => (
+  <Svg
+    {...props}
+    ref={ref}
+    height={size}
+    width={size}
+    style={{ height: size, width: size }}
+    viewBox={`0 0 ${dataSize} ${dataSize}`}
+  >
+    <Rect x={0} y={0} width={dataSize} height={dataSize} fill={bgColor}/>
     {children}
   </Svg>
 ));

--- a/src/components/QRCodeSurface/index.native.js
+++ b/src/components/QRCodeSurface/index.native.js
@@ -1,16 +1,19 @@
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
-import { Svg } from "react-native-svg";
+import { Svg, Rect } from "react-native-svg";
 
 const propTypes = {
   children: PropTypes.array.isRequired,
   size: PropTypes.number.isRequired,
+  length: PropTypes.number.isRequired,
+  bgColor: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
-const QRCodeSurface = forwardRef(({ children, size, ...props }, ref) => (
+const QRCodeSurface = forwardRef(({ children, size, length, bgColor, ...props }, ref) => (
   <Svg {...props} height={size} ref={ref} style={{ height: size, width: size }} width={size}>
+    <Rect x={0} y={0} width={length} height={length} fill={bgColor}/>
     {children}
   </Svg>
 ));

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ const QRCode = forwardRef(({ bgColor, fgColor, level, size, value, ...props }, r
   qrcode.make();
   const cells = qrcode.modules;
   return (
-    <QRCodeSurface {...props} size={size} ref={ref} length={cells.length} bgColor={bgColor}>
+    <QRCodeSurface {...props} size={size} ref={ref} dataSize={cells.length} bgColor={bgColor}>
       <QRCodeCell
         d={makePath(cells)}
         fill={fgColor}

--- a/src/index.js
+++ b/src/index.js
@@ -27,15 +27,16 @@ const QRCode = forwardRef(({ bgColor, fgColor, level, size, value, ...props }, r
   qrcode.addData(value);
   qrcode.make();
   const cells = qrcode.modules;
-  const tileSize = size / cells.length;
+  const viewBox = `0 0 ${cells.length} ${cells.length}`
+
   return (
-    <QRCodeSurface {...props} size={size} ref={ref}>
+    <QRCodeSurface {...props} size={size} ref={ref} viewBox={viewBox}>
       {cells.map((row, rowIndex) =>
         row.map((cell, cellIndex) => {
-          const transformX = Math.round(cellIndex * tileSize);
-          const transformY = Math.round(rowIndex * tileSize);
-          const qrItemWidth = Math.round((cellIndex + 1) * tileSize) - transformX;
-          const qrItemHeight = Math.round((rowIndex + 1) * tileSize) - transformY;
+          const transformX = cellIndex;
+          const transformY = rowIndex;
+          const qrItemWidth = 1;
+          const qrItemHeight = 1;
           return (
             <QRCodeCell
               /* eslint-disable react/no-array-index-key */

--- a/src/index.js
+++ b/src/index.js
@@ -27,33 +27,33 @@ const QRCode = forwardRef(({ bgColor, fgColor, level, size, value, ...props }, r
   qrcode.addData(value);
   qrcode.make();
   const cells = qrcode.modules;
-  const viewBox = `0 0 ${cells.length} ${cells.length}`
-
   return (
-    <QRCodeSurface {...props} size={size} ref={ref} viewBox={viewBox}>
+    <QRCodeSurface {...props} size={size} ref={ref} length={cells.length} bgColor={bgColor}>
       {cells.map((row, rowIndex) =>
         row.map((cell, cellIndex) => {
-          const transformX = cellIndex;
-          const transformY = rowIndex;
-          const qrItemWidth = 1;
-          const qrItemHeight = 1;
-          return (
+          const posX = cellIndex;
+          const posY = rowIndex;
+          return cell ? (
             <QRCodeCell
               /* eslint-disable react/no-array-index-key */
               key={`rectangle-${rowIndex}-${cellIndex}`}
               /* eslint-enable react/no-array-index-key */
-              d={`M 0 0 L ${qrItemWidth} 0 L ${qrItemWidth} ${qrItemHeight} L 0 ${qrItemHeight} Z`}
-              fill={cell ? fgColor : bgColor}
-              transformX={transformX}
-              transformY={transformY}
+              d={`M ${posX} ${posY} l 1 0 0 1 -1 0 Z`}
+              /* The path explained
+                M  x y    // absolute move to x and y coordinate
+                l  1 0    // relative line to x+1
+                   0 1    // relative line to y+1
+                  -1 0    // relative line to x-1
+                Z         // close path
+              */
+              fill={fgColor}
             />
-          );
+          ) : null; // Return nothing if empty pixel
         })
       )}
     </QRCodeSurface>
   );
 });
-
 QRCode.displayName = "QRCode";
 QRCode.propTypes = propTypes;
 QRCode.defaultProps = defaultProps;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,24 @@ const defaultProps = {
   size: 256,
 };
 
+function makePath(cells) {
+    /**  How each cell is drawn:
+     *
+     *    M  x y    // absolute move to x and y coordinate
+     *    l  1 0    // relative line to x+1
+     *       0 1    // relative line to y+1
+     *      -1 0    // relative line to x-1
+     *    Z         // close path
+     */
+    return cells.map((row, rowIndex) =>
+        row.map((cell, cellIndex) => {
+            const posX = cellIndex
+            const posY = rowIndex
+            return cell ? `M ${posX} ${posY} l 1 0 0 1 -1 0 Z` : "" // Return nothing if empty pixel
+        }).join(" "),
+    ).join(" ")
+}
+
 const QRCode = forwardRef(({ bgColor, fgColor, level, size, value, ...props }, ref) => {
   // We'll use type === -1 to force QRCode to automatically pick the best type.
   const qrcode = new QRCodeImpl(-1, ErrorCorrectLevel[level]);
@@ -29,28 +47,10 @@ const QRCode = forwardRef(({ bgColor, fgColor, level, size, value, ...props }, r
   const cells = qrcode.modules;
   return (
     <QRCodeSurface {...props} size={size} ref={ref} length={cells.length} bgColor={bgColor}>
-      {cells.map((row, rowIndex) =>
-        row.map((cell, cellIndex) => {
-          const posX = cellIndex;
-          const posY = rowIndex;
-          return cell ? (
-            <QRCodeCell
-              /* eslint-disable react/no-array-index-key */
-              key={`rectangle-${rowIndex}-${cellIndex}`}
-              /* eslint-enable react/no-array-index-key */
-              d={`M ${posX} ${posY} l 1 0 0 1 -1 0 Z`}
-              /* The path explained
-                M  x y    // absolute move to x and y coordinate
-                l  1 0    // relative line to x+1
-                   0 1    // relative line to y+1
-                  -1 0    // relative line to x-1
-                Z         // close path
-              */
-              fill={fgColor}
-            />
-          ) : null; // Return nothing if empty pixel
-        })
-      )}
+      <QRCodeCell
+        d={makePath(cells)}
+        fill={fgColor}
+      />
     </QRCodeSurface>
   );
 });


### PR DESCRIPTION
I noticed that unless you set the size to an exact multiple of the number of cells; so for a relatively small qr code with 33x33 cells you need to set the size as 33 or 66 or 330 etc. otherwise a handful of the cells will be rounded up or down creating non-square pixels.
<img width="293" alt="Skjermbilde 2022-10-26 kl  12 48 21" src="https://user-images.githubusercontent.com/2144849/198007662-f8001081-7b7d-4df2-bc87-f16af30625b6.png">
Notice the non-square pixels:
<img width="920" alt="Skjermbilde 2022-10-26 kl  12 49 04" src="https://user-images.githubusercontent.com/2144849/198007720-8ecbe851-ea76-4b4c-9558-6b3050548cf7.png">

Not only does it look slightly awkward with those rounding errors and reduce readability somewhat; but if you set the size anywhere close to (but not exactly) the number of cells the code will have, the qr-code will be completely broken:
<img width="317" alt="Skjermbilde 2022-10-26 kl  15 00 12" src="https://user-images.githubusercontent.com/2144849/198032632-a30dbe7e-7804-4498-a2b5-128d987bb0d3.png">
<img width="319" alt="Skjermbilde 2022-10-26 kl  15 01 25" src="https://user-images.githubusercontent.com/2144849/198032636-70f02f2c-e28b-472f-bf73-2e1eb7817926.png">


I realised I could fix the rounding by changing from viewBox being one of the optional parameters to be be set to the size of the qr-code in cells. 
Then I could also simplify the paths a lot by using unit sized cells and let the viewbox take care of the final scaling.
This way the maximum rounding error is one native pixel rather than a rather large fraction of the cell, which should be much better for readability.

Once all the cell-size calculations were simplified to using 1 I realised the paths outputted was pretty repetetive and could be written more compactly. Also by using a single `<rect />` for the background I could practically halve the number of path elements by outputting only the foreground pixels. Just to further reduce the DOM size I changed from using transforms to using absolute positioned move and relative lines in the d property of the path.

After these changes:
<img width="293" alt="Skjermbilde 2022-10-26 kl  12 47 22" src="https://user-images.githubusercontent.com/2144849/198007804-60bdd240-216e-4e45-a010-682a43f89dda.png">

This is readable at any size as long as theres sufficient quietzone around it and it's physically large enough for the camera to focus on it.