### PR TITLE
fix: render() return type to ReactNode for React 19 (#273)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,7 +10,7 @@ declare module "react-qr-code" {
   }
 
   class QRCode extends React.Component<QRCodeProps, any> {
-    render(): JSX.Element;
+    render(): React.ReactNode;
   }
 
   export default QRCode;


### PR DESCRIPTION
Fixes #273.

React 19 expects render() to return ReactNode, not JSX.Element

Backwards‐compatibility: Since JSX.Element extends ReactNode, existing React <19 users are unaffected.