### PR TITLE
Keep solid principles on qr code type to avoid breaking changes

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,7 @@ declare module "react-qr-code" {
     bgColor?: React.CSSProperties["backgroundColor"]; // defaults to "#FFFFFF"
     fgColor?: React.CSSProperties["color"]; // defaults to "#000000"
     level?: "L" | "M" | "H" | "Q"; // defaults to "L"
-    title: string;
+    title?: string;
   }
 
   class QRCode extends React.Component<QRCodeProps, any> {


### PR DESCRIPTION
Recently, the mandatory property title of the QrCode component typing was added, which caused breakages resulting in build problems for projects that use this component. I changed the property to non-mandatory to follow solid evolution principles.