### PR TITLE
code: Update typedefs to correctly reflect underlying code

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,9 +10,7 @@ declare module "react-qr-code" {
     title?: string;
   }
 
-  class QRCode extends React.Component<QRCodeProps, any> {
+  export class QRCode extends React.Component<QRCodeProps, any> {
     render(): React.ReactNode;
   }
-
-  export default QRCode;
 }


### PR DESCRIPTION
This is a fix for Vite v8, as mentioned in issue #285 `import { QRCode } from "react-qr-code";` is the correct way to import the class in typescript