### PR TITLE
fix: add types to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "react-native": "./lib/index.native.js",
       "import": "./lib/index.mjs",
       "require": "./lib/index.js",
-      "default": "./lib/index.js"
+      "default": "./lib/index.js",
+      "types": "./types/index.d.ts"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Add the "types" entry to package.json exports

Without this Typescript fails to resolve the types of the library when using "resolvePackageJsonExports"

According to [arethetypeswrong](https://www.npmjs.com/package/@arethetypeswrong/cli) now the resolution should work. It uses fallback resolutions as there is just one .ts but both a cjs and es module build output from rollup

